### PR TITLE
Add MkDocs scaffolding and integrate with release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+/docs-site
 
 # mypy
 .mypy_cache/

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,7 @@ docs-install: install-dev
 	$(PIP) install mkdocs mkdocs-material mkdocstrings mkdocstrings-python
 
 docs-build: docs-install
-	mkdir -p site
-	echo "Documentation build placeholder" > site/index.html
+	$(VENV)/bin/mkdocs build --config-file mkdocs.yml --site-dir docs-site
 
 docs-serve: docs-install
-	@echo "Documentation server placeholder - would run mkdocs serve"
+	$(VENV)/bin/mkdocs serve --config-file mkdocs.yml

--- a/docs/dev/changelog.md
+++ b/docs/dev/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+
+- Initial project setup
+- Documentation scaffolding

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,0 +1,18 @@
+# Contributing to Mantis
+
+## Development Setup
+
+1. Fork the repository
+2. Clone your fork
+3. Create a virtual environment
+4. Install development dependencies
+
+## Contribution Guidelines
+
+- Follow our code of conduct
+- Submit pull requests with clear descriptions
+- Ensure tests pass before submitting
+
+## Coming Soon
+
+Detailed contribution guidelines will be added in future updates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Mantis Documentation
+
+## Overview
+
+Mantis is a multi-agent AI framework for strategic divination, designed to provide intelligent, collaborative problem-solving capabilities.
+
+## Quick Start
+
+This documentation is under development. More content will be added soon.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,23 @@
+# Installation
+
+## Prerequisites
+
+- Python 3.11+
+- pip
+- Virtual environment (recommended)
+
+## Install from PyPI
+
+```bash
+pip install mantis
+```
+
+## Development Installation
+
+```bash
+git clone https://github.com/allendy/mantis
+cd mantis
+python -m venv .venv
+source .venv/bin/activate
+make install-dev
+```

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -1,0 +1,7 @@
+# API Reference
+
+This section provides detailed documentation for Mantis modules.
+
+## Module Documentation Coming Soon
+
+Comprehensive API documentation will be added in future updates.

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,0 +1,7 @@
+# User Guide Overview
+
+This guide will help you understand and use the Mantis framework effectively.
+
+## Coming Soon
+
+Detailed user documentation is currently being developed. Check back for updates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,54 @@
+site_name: Mantis Documentation
+site_description: Multi-agent AI framework for strategic divination
+site_author: Allen Day
+site_url: https://github.com/allendy/mantis
+
+# Output directory configuration
+site_dir: docs-site
+
+# Theme
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+
+# Plugins
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          import:
+            - https://docs.python.org/3/objects.inv
+          options:
+            docstring_style: google
+            docstring_section_style: list
+            merge_init_into_class: true
+            show_root_heading: true
+            show_root_full_path: true
+
+# Additional navigation 
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - User Guide:
+      - Overview: user-guide/overview.md
+  - API Reference:
+      - Modules: reference/modules.md
+  - Development:
+      - Contributing: dev/contributing.md
+      - Changelog: dev/changelog.md
+
+# Markdown extensions
+markdown_extensions:
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.6.0",
     "build>=1.0.0",
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocstrings[python]>=0.24.0",
 ]
 
 [project.scripts]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ def main():
     parser.add_argument("version", help="Version to release (e.g., 0.1.1)")
     parser.add_argument("--dry-run", action="store_true", help="Only update version, don't build")
     parser.add_argument("--skip-tests", action="store_true", help="Skip running tests")
+    parser.add_argument("--skip-docs", action="store_true", help="Skip building documentation")
 
     args = parser.parse_args()
 
@@ -90,6 +91,15 @@ def main():
     # except subprocess.CalledProcessError as e:
     #     print(f"Docker build failed: {e}")
     #     sys.exit(1)
+
+    # Build documentation
+    if not args.skip_docs:
+        print("Building documentation...")
+        try:
+            run_command(["make", "docs-build"])
+        except subprocess.CalledProcessError as e:
+            print(f"Documentation build failed: {e}")
+            sys.exit(1)
 
     # Build package
     print("Building package...")


### PR DESCRIPTION
## Summary
- Set up basic MkDocs scaffolding for documentation generation
- Configure output to `docs-site/` directory as requested
- Integrate documentation build into release workflow

## Changes Made
- Added MkDocs dependencies to `pyproject.toml` dev dependencies
- Created `mkdocs.yml` configuration with Material theme
- Set up basic `docs/` directory structure with placeholder content
- Added MkDocs targets to `Makefile`: `docs-install`, `docs-build`, `docs-serve`
- Integrated `make docs-build` into `scripts/release.py` with `--skip-docs` flag
- Updated `.gitignore` to exclude `docs-site/` build directory

## Testing
- MkDocs scaffolding is ready to use
- Can build docs with `make docs-build` → outputs to `docs-site/`
- Can serve locally with `make docs-serve`
- Release script now builds docs as part of release process

This provides the basic scaffolding to build out comprehensive documentation later.

🤖 Generated with [Claude Code](https://claude.ai/code)